### PR TITLE
Make extra fields available for physical location

### DIFF
--- a/data-model.json
+++ b/data-model.json
@@ -13,6 +13,8 @@
         "country": "",
         "province": "",
         "county": "",
+        "municipality": "",
+        "locality": ""
       }
     },
     "transcriptionEvent": {


### PR DESCRIPTION
Should we add extra location fields to the contributor's physical location?  In Australia, we generally don't use counties / shires and our user accounts can have self reported locations down to the municipality level.
